### PR TITLE
feat: add ProgressBar type

### DIFF
--- a/src/interfaces.ts
+++ b/src/interfaces.ts
@@ -22,3 +22,7 @@ export type BaseOptions = {
 export type ProgressBarOptions = BaseOptions & {
   value: ValueOptions | ValueOptions[]
 }
+
+export type ProgressBar = {
+  render(...values: number[]): string
+}

--- a/src/progressBar.ts
+++ b/src/progressBar.ts
@@ -1,11 +1,11 @@
 import { RecursivePartial } from 'type-plus';
 import { unpartial, unpartialRecursively } from 'unpartial';
 import { defaultBaseOptions, defaultValueOptions } from './defaultOptions';
-import { ProgressBarOptions, ValueOptions } from './interfaces';
+import { ProgressBarOptions, ValueOptions, ProgressBar } from './interfaces';
 import { renderBar } from './renderBar';
 import { validateBarFormat, validateLength, validateValueOptions } from './validate';
 
-export function progressBar(options?: RecursivePartial<ProgressBarOptions>) {
+export function progressBar(options?: RecursivePartial<ProgressBarOptions>): ProgressBar {
   const { length, textPosition, textStyle, textTransform, valueOptions, bar, defaultValueOptions } = extractOptions(options)
 
   const baseOption = { bar, length, textPosition, textStyle, textTransform }


### PR DESCRIPTION
for easy reference instead of `ReturnType<typeof progressBar>`